### PR TITLE
latest -> release-specific tag (18.0.1)

### DIFF
--- a/apps/atuin/config.json
+++ b/apps/atuin/config.json
@@ -6,7 +6,7 @@
   "port": 8888,
   "id": "atuin",
   "tipi_version": 1,
-  "version": "latest",
+  "version": "18.0.1",
   "categories": [
     "utilities",
     "development"

--- a/apps/atuin/docker-compose.yml
+++ b/apps/atuin/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   atuin:
     container_name: atuin
     restart: always
-    image: ghcr.io/atuinsh/atuin:latest
+    image: ghcr.io/atuinsh/atuin:18.0.1
     command: server start
     volumes:
       - "${APP_DATA_DIR}:/config"


### PR DESCRIPTION
Atuin maintainers strongly suggest this anyway, and I believe this will also enlist Atuin in Renovate's auto-updates.